### PR TITLE
Add JWT authentication filter

### DIFF
--- a/src/main/java/fr/thomasdindin/barapp/controllers/AuthController.java
+++ b/src/main/java/fr/thomasdindin/barapp/controllers/AuthController.java
@@ -1,5 +1,6 @@
 package fr.thomasdindin.barapp.controllers;
 
+import fr.thomasdindin.barapp.dto.JwtResponse;
 import fr.thomasdindin.barapp.dto.LoginRequest;
 import fr.thomasdindin.barapp.utils.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,7 @@ public class AuthController {
     private final JwtUtil               jwtUtil;
 
     @PostMapping(path = "/login")
-    public ResponseEntity<String> login(
+    public ResponseEntity<JwtResponse> login(
             @Validated @RequestBody LoginRequest request) {
 
         authenticationManager.authenticate(
@@ -41,7 +42,7 @@ public class AuthController {
 
         return ResponseEntity
                 .ok()
-                .body(jwt);
+                .body(new JwtResponse(jwt));
     }
 }
 

--- a/src/main/java/fr/thomasdindin/barapp/dto/JwtResponse.java
+++ b/src/main/java/fr/thomasdindin/barapp/dto/JwtResponse.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
+@Getter
 @RequiredArgsConstructor
 public class JwtResponse {
     private final String token;

--- a/src/main/java/fr/thomasdindin/barapp/security/JwtAuthenticationFilter.java
+++ b/src/main/java/fr/thomasdindin/barapp/security/JwtAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package fr.thomasdindin.barapp.security;
+
+import fr.thomasdindin.barapp.services.UtilisateurServiceImpl;
+import fr.thomasdindin.barapp.utils.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UtilisateurServiceImpl utilisateurServiceImpl;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            String username = jwtUtil.extractUsername(token);
+            if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = utilisateurServiceImpl.loadUserByUsername(username);
+                if (jwtUtil.validateToken(token, userDetails)) {
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/fr/thomasdindin/barapp/security/SecurityConfig.java
+++ b/src/main/java/fr/thomasdindin/barapp/security/SecurityConfig.java
@@ -1,13 +1,13 @@
 package fr.thomasdindin.barapp.security;
 
 import fr.thomasdindin.barapp.services.UtilisateurServiceImpl;
+import fr.thomasdindin.barapp.utils.JwtUtil;
+import fr.thomasdindin.barapp.security.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -15,6 +15,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -50,7 +51,9 @@ public class SecurityConfig {
      * 3) Chaîne de filtres : on définit nos règles d’accès, CSRF, session, etc.
      */
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   JwtUtil jwtUtil,
+                                                   UtilisateurServiceImpl utilisateurServiceImpl) throws Exception {
         http
                 // désactivation CSRF (adapter si vous avez des formulaires)
                 .csrf(AbstractHttpConfigurer::disable)
@@ -70,6 +73,9 @@ public class SecurityConfig {
                 // on désactive formLogin et HTTP Basic par défaut
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable);
+
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtUtil, utilisateurServiceImpl),
+                UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/fr/thomasdindin/barapp/utils/JwtUtil.java
+++ b/src/main/java/fr/thomasdindin/barapp/utils/JwtUtil.java
@@ -1,5 +1,6 @@
 package fr.thomasdindin.barapp.utils;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,5 +27,26 @@ public class JwtUtil {
                 .expiration(expiry)
                 .signWith(SignatureAlgorithm.HS512, secretKey)
                 .compact();
+    }
+
+    public String extractUsername(String token) {
+        return extractAllClaims(token).getSubject();
+    }
+
+    public boolean validateToken(String token, UserDetails userDetails) {
+        String username = extractUsername(token);
+        return username.equals(userDetails.getUsername()) && !isTokenExpired(token);
+    }
+
+    private boolean isTokenExpired(String token) {
+        Date expiration = extractAllClaims(token).getExpiration();
+        return expiration.before(new Date());
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody();
     }
 }


### PR DESCRIPTION
## Summary
- create `JwtAuthenticationFilter` to handle token auth
- validate and parse JWT with new utilities
- include the filter in security chain
- return a structured `JwtResponse` on login

## Testing
- `./mvnw -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686274f0c3408332963d4f191b9a12fd