### PR TITLE
Implement order management

### DIFF
--- a/src/main/java/fr/thomasdindin/barapp/controllers/CommandeController.java
+++ b/src/main/java/fr/thomasdindin/barapp/controllers/CommandeController.java
@@ -1,0 +1,41 @@
+package fr.thomasdindin.barapp.controllers;
+
+import fr.thomasdindin.barapp.dto.CommandeDto;
+import fr.thomasdindin.barapp.enums.StatutCommande;
+import fr.thomasdindin.barapp.services.CommandeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/commandes")
+@RequiredArgsConstructor
+public class CommandeController {
+    private final CommandeService commandeService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('CLIENT')")
+    public ResponseEntity<CommandeDto> createCommande(@RequestBody CommandeDto commande) {
+        return ResponseEntity.ok(commandeService.createCommande(commande));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CommandeDto>> getAll() {
+        return ResponseEntity.ok(commandeService.getAllCommandes());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<CommandeDto> getById(@PathVariable int id) {
+        return ResponseEntity.ok(commandeService.getCommandeById(id));
+    }
+
+    @PutMapping("/lignes/{id}")
+    @PreAuthorize("hasRole('BARMAKER')")
+    public ResponseEntity<CommandeDto> updateLigneStatus(@PathVariable int id,
+                                                         @RequestParam StatutCommande statut) {
+        return ResponseEntity.ok(commandeService.updateLigneStatus(id, statut));
+    }
+}

--- a/src/main/java/fr/thomasdindin/barapp/entities/LigneCommande.java
+++ b/src/main/java/fr/thomasdindin/barapp/entities/LigneCommande.java
@@ -27,5 +27,4 @@ public class LigneCommande {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "id_variante", nullable = false)
     private Variante idVariante;
-
 }

--- a/src/main/java/fr/thomasdindin/barapp/enums/StatutCommande.java
+++ b/src/main/java/fr/thomasdindin/barapp/enums/StatutCommande.java
@@ -1,0 +1,17 @@
+package fr.thomasdindin.barapp.enums;
+
+public enum StatutCommande {
+    EN_ATTENTE("En attente"),
+    EN_PREPARATION("En cours de préparation"),
+    TERMINE("Terminé");
+
+    private final String libelle;
+
+    StatutCommande(String libelle) {
+        this.libelle = libelle;
+    }
+
+    public String getLibelle() {
+        return libelle;
+    }
+}

--- a/src/main/java/fr/thomasdindin/barapp/mappers/CommandeMapper.java
+++ b/src/main/java/fr/thomasdindin/barapp/mappers/CommandeMapper.java
@@ -1,0 +1,55 @@
+package fr.thomasdindin.barapp.mappers;
+
+import fr.thomasdindin.barapp.dto.CommandeDto;
+import fr.thomasdindin.barapp.dto.LigneCommandeDto;
+import fr.thomasdindin.barapp.dto.UtilisateurDto;
+import fr.thomasdindin.barapp.entities.Commande;
+import fr.thomasdindin.barapp.entities.LigneCommande;
+import fr.thomasdindin.barapp.entities.Utilisateur;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class CommandeMapper {
+    public static CommandeDto toDto(Commande entity) {
+        if (entity == null) return null;
+        Utilisateur u = entity.getIdUtilisateur();
+        UtilisateurDto userDto = null;
+        if (u != null) {
+            userDto = new UtilisateurDto(u.getId(), u.getNom(), u.getPrenom());
+        }
+        Set<LigneCommandeDto> lignes = entity.getLigneCommandes().stream()
+                .map(LigneCommandeMapper::toDto)
+                .collect(Collectors.toSet());
+        return new CommandeDto(
+                entity.getId(),
+                entity.getDateCommande(),
+                entity.getStatut(),
+                userDto,
+                lignes
+        );
+    }
+
+    public static Commande toEntity(CommandeDto dto) {
+        if (dto == null) return null;
+        Commande entity = new Commande();
+        entity.setId(dto.id());
+        entity.setDateCommande(dto.dateCommande());
+        entity.setStatut(dto.statut());
+        if (dto.idUtilisateur() != null) {
+            Utilisateur user = new Utilisateur();
+            user.setId(dto.idUtilisateur().id());
+            user.setNom(dto.idUtilisateur().nom());
+            user.setPrenom(dto.idUtilisateur().prenom());
+            entity.setIdUtilisateur(user);
+        }
+        if (dto.ligneCommandes() != null) {
+            Set<LigneCommande> lignes = dto.ligneCommandes().stream()
+                    .map(LigneCommandeMapper::toEntity)
+                    .peek(l -> l.setIdCommande(entity))
+                    .collect(Collectors.toSet());
+            entity.setLigneCommandes(lignes);
+        }
+        return entity;
+    }
+}

--- a/src/main/java/fr/thomasdindin/barapp/mappers/LigneCommandeMapper.java
+++ b/src/main/java/fr/thomasdindin/barapp/mappers/LigneCommandeMapper.java
@@ -1,0 +1,26 @@
+package fr.thomasdindin.barapp.mappers;
+
+import fr.thomasdindin.barapp.dto.LigneCommandeDto;
+import fr.thomasdindin.barapp.entities.LigneCommande;
+
+public class LigneCommandeMapper {
+    public static LigneCommandeDto toDto(LigneCommande entity) {
+        if (entity == null) return null;
+        return new LigneCommandeDto(
+                entity.getId(),
+                entity.getQte(),
+                entity.getStatut(),
+                VarianteMapper.toDto(entity.getIdVariante())
+        );
+    }
+
+    public static LigneCommande toEntity(LigneCommandeDto dto) {
+        if (dto == null) return null;
+        LigneCommande entity = new LigneCommande();
+        entity.setId(dto.id());
+        entity.setQte(dto.qte());
+        entity.setStatut(dto.statut());
+        entity.setIdVariante(VarianteMapper.toEntity(dto.idVariante(), null));
+        return entity;
+    }
+}

--- a/src/main/java/fr/thomasdindin/barapp/repositories/LigneCommandeRepository.java
+++ b/src/main/java/fr/thomasdindin/barapp/repositories/LigneCommandeRepository.java
@@ -1,0 +1,7 @@
+package fr.thomasdindin.barapp.repositories;
+
+import fr.thomasdindin.barapp.entities.LigneCommande;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LigneCommandeRepository extends JpaRepository<LigneCommande, Integer> {
+}

--- a/src/main/java/fr/thomasdindin/barapp/services/CommandeService.java
+++ b/src/main/java/fr/thomasdindin/barapp/services/CommandeService.java
@@ -1,6 +1,13 @@
 package fr.thomasdindin.barapp.services;
 
+import fr.thomasdindin.barapp.dto.CommandeDto;
+import fr.thomasdindin.barapp.enums.StatutCommande;
+
 import java.util.List;
 
 public interface CommandeService {
+    CommandeDto createCommande(CommandeDto commande);
+    List<CommandeDto> getAllCommandes();
+    CommandeDto getCommandeById(int id);
+    CommandeDto updateLigneStatus(int idLigne, StatutCommande statut);
 }

--- a/src/main/java/fr/thomasdindin/barapp/services/CommandeServiceImpl.java
+++ b/src/main/java/fr/thomasdindin/barapp/services/CommandeServiceImpl.java
@@ -1,13 +1,112 @@
 package fr.thomasdindin.barapp.services;
 
+import fr.thomasdindin.barapp.dto.CommandeDto;
+import fr.thomasdindin.barapp.enums.StatutCommande;
+import fr.thomasdindin.barapp.entities.Commande;
+import fr.thomasdindin.barapp.entities.LigneCommande;
+import fr.thomasdindin.barapp.entities.Utilisateur;
+import fr.thomasdindin.barapp.entities.Variante;
+import fr.thomasdindin.barapp.mappers.CommandeMapper;
 import fr.thomasdindin.barapp.repositories.CommandeRepository;
+import fr.thomasdindin.barapp.repositories.LigneCommandeRepository;
+import fr.thomasdindin.barapp.repositories.UtilisateurRepository;
+import fr.thomasdindin.barapp.repositories.VarianteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.ResourceAccessException;
+
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class CommandeServiceImpl implements CommandeService {
     private final CommandeRepository commandeRepository;
+    private final LigneCommandeRepository ligneCommandeRepository;
+    private final VarianteRepository varianteRepository;
+    private final UtilisateurRepository utilisateurRepository;
 
+    @Override
+    @Transactional
+    public CommandeDto createCommande(CommandeDto dto) {
+        if (dto == null || dto.idUtilisateur() == null) {
+            throw new IllegalArgumentException("Commande sans utilisateur");
+        }
+        Utilisateur user = utilisateurRepository.findById(dto.idUtilisateur().id())
+                .orElseThrow(() -> new ResourceAccessException("Utilisateur non trouve"));
+        Commande commande = new Commande();
+        commande.setDateCommande(Instant.now());
+        commande.setStatut(StatutCommande.EN_ATTENTE.getLibelle());
+        commande.setIdUtilisateur(user);
+        Commande saved = commandeRepository.save(commande);
 
+        Set<LigneCommande> lignes = new LinkedHashSet<>();
+        if (dto.ligneCommandes() != null) {
+            for (var lDto : dto.ligneCommandes()) {
+                LigneCommande lc = new LigneCommande();
+                lc.setIdCommande(saved);
+                lc.setQte(lDto.qte());
+                lc.setStatut(StatutCommande.EN_ATTENTE.getLibelle());
+                Variante variante = varianteRepository.findById(lDto.idVariante().id())
+                        .orElseThrow(() -> new ResourceAccessException("Variante non trouvee"));
+                lc.setIdVariante(variante);
+                lignes.add(ligneCommandeRepository.save(lc));
+            }
+        }
+        saved.setLigneCommandes(lignes);
+        return CommandeMapper.toDto(saved);
+    }
+
+    @Override
+    public List<CommandeDto> getAllCommandes() {
+        return commandeRepository.findAll().stream()
+                .map(CommandeMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public CommandeDto getCommandeById(int id) {
+        return commandeRepository.findById(id)
+                .map(CommandeMapper::toDto)
+                .orElseThrow(() -> new ResourceAccessException("Commande"+id+" not found"));
+    }
+
+    @Override
+    @Transactional
+    public CommandeDto updateLigneStatus(int idLigne, StatutCommande statut) {
+        LigneCommande ligne = ligneCommandeRepository.findById(idLigne)
+                .orElseThrow(() -> new ResourceAccessException("Ligne"+idLigne+" not found"));
+        ligne.setStatut(statut.getLibelle());
+        ligneCommandeRepository.save(ligne);
+
+        Commande commande = commandeRepository.findById(ligne.getIdCommande().getId())
+                .orElseThrow(() -> new ResourceAccessException("Commande"+ligne.getIdCommande().getId()+" not found"));
+
+        boolean allDone = true;
+        boolean anyPrep = false;
+        for (LigneCommande lc : commande.getLigneCommandes()) {
+            String st = lc.getId().equals(idLigne) ? statut.getLibelle() : lc.getStatut();
+            if (!StatutCommande.TERMINE.getLibelle().equals(st)) {
+                allDone = false;
+            }
+            if (StatutCommande.EN_PREPARATION.getLibelle().equals(st)) {
+                anyPrep = true;
+            }
+        }
+        String newStatut = commande.getStatut();
+        if (allDone) {
+            newStatut = StatutCommande.TERMINE.getLibelle();
+        } else if (anyPrep) {
+            newStatut = StatutCommande.EN_PREPARATION.getLibelle();
+        } else {
+            newStatut = StatutCommande.EN_ATTENTE.getLibelle();
+        }
+        commande.setStatut(newStatut);
+        commandeRepository.save(commande);
+        return CommandeMapper.toDto(commande);
+    }
 }


### PR DESCRIPTION
## Summary
- add `StatutCommande` enum for order states
- map `Commande` and `LigneCommande` entities to DTOs
- implement `CommandeService` logic with status updates
- expose REST endpoints in `CommandeController`
- create repository for `LigneCommande`
- clean up `LigneCommande` entity

## Testing
- `./mvnw -q test` *(fails: could not download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68652f0899448332aec18f40c8a8bc1b