### PR TITLE
Add unit tests for services

### DIFF
--- a/src/test/java/fr/thomasdindin/barapp/services/CategorieServiceImplTest.java
+++ b/src/test/java/fr/thomasdindin/barapp/services/CategorieServiceImplTest.java
@@ -1,0 +1,93 @@
+import fr.thomasdindin.barapp.dto.CategorieDto;
+import fr.thomasdindin.barapp.entities.Categorie;
+import fr.thomasdindin.barapp.repositories.CategorieRepository;
+import fr.thomasdindin.barapp.services.CategorieServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CategorieServiceImplTest {
+
+    @Mock
+    private CategorieRepository repository;
+
+    @InjectMocks
+    private CategorieServiceImpl service;
+
+    private Categorie entity;
+
+    @BeforeEach
+    void setup() {
+        entity = new Categorie();
+        entity.setIdCategorie(1);
+        entity.setLibelle("Cocktails");
+    }
+
+    @Test
+    void createCategory_shouldSaveAndReturnDto() {
+        when(repository.save(any(Categorie.class))).thenReturn(entity);
+
+        CategorieDto dto = new CategorieDto(null, "Cocktails");
+        CategorieDto result = service.createCategory(dto);
+
+        assertThat(result.idCategorie()).isEqualTo(1);
+        assertThat(result.libelle()).isEqualTo("Cocktails");
+        verify(repository).save(any(Categorie.class));
+    }
+
+    @Test
+    void getAllCategories_returnsMappedDtos() {
+        when(repository.findAll()).thenReturn(List.of(entity));
+
+        List<CategorieDto> list = service.getAllCategories();
+
+        assertThat(list).hasSize(1);
+        assertThat(list.get(0).libelle()).isEqualTo("Cocktails");
+    }
+
+    @Test
+    void getCategoryById_whenFound() {
+        when(repository.findById(1)).thenReturn(Optional.of(entity));
+
+        CategorieDto dto = service.getCategoryById(1);
+
+        assertThat(dto.idCategorie()).isEqualTo(1);
+    }
+
+    @Test
+    void getCategoryById_whenMissing_throws() {
+        when(repository.findById(1)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getCategoryById(1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void updateCategory_shouldSave() {
+        when(repository.save(any(Categorie.class))).thenReturn(entity);
+        CategorieDto dto = new CategorieDto(1, "Cocktails");
+
+        CategorieDto res = service.updateCategory(dto);
+
+        assertThat(res.idCategorie()).isEqualTo(1);
+        verify(repository).save(any(Categorie.class));
+    }
+
+    @Test
+    void deleteCategory_callsRepository() {
+        service.deleteCategory(42);
+        verify(repository).deleteById(42);
+    }
+}

--- a/src/test/java/fr/thomasdindin/barapp/services/CocktailServiceImplTest.java
+++ b/src/test/java/fr/thomasdindin/barapp/services/CocktailServiceImplTest.java
@@ -1,0 +1,101 @@
+import fr.thomasdindin.barapp.dto.CategorieDto;
+import fr.thomasdindin.barapp.dto.CocktailDto;
+import fr.thomasdindin.barapp.dto.VarianteDto;
+import fr.thomasdindin.barapp.entities.Categorie;
+import fr.thomasdindin.barapp.entities.Cocktail;
+import fr.thomasdindin.barapp.entities.Variante;
+import fr.thomasdindin.barapp.repositories.CocktailRepository;
+import fr.thomasdindin.barapp.repositories.VarianteRepository;
+import fr.thomasdindin.barapp.services.CocktailServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.ResourceAccessException;
+
+import java.math.BigDecimal;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CocktailServiceImplTest {
+
+    @Mock
+    private CocktailRepository cocktailRepository;
+    @Mock
+    private VarianteRepository varianteRepository;
+    @InjectMocks
+    private CocktailServiceImpl service;
+
+    private CocktailDto inputDto;
+    private Cocktail savedEntity;
+
+    @BeforeEach
+    void setup() {
+        VarianteDto varianteDto = new VarianteDto(null, "M", BigDecimal.ONE, 0);
+        inputDto = new CocktailDto(null, "Mojito", "desc", Collections.emptySet(), Set.of(varianteDto), new CategorieDto(1, "cat"));
+        savedEntity = new Cocktail();
+        savedEntity.setId(1);
+        savedEntity.setLibelle("Mojito");
+        savedEntity.setDescription("desc");
+        Categorie cat = new Categorie();
+        cat.setIdCategorie(1);
+        cat.setLibelle("cat");
+        savedEntity.setCategorie(cat);
+        savedEntity.setVariantes(new LinkedHashSet<>());
+    }
+
+    @Test
+    void createCocktail_persistsVariantsAndReturnsDto() {
+        when(cocktailRepository.save(any(Cocktail.class))).thenReturn(savedEntity);
+
+        CocktailDto result = service.createCocktail(inputDto);
+
+        verify(cocktailRepository).save(any(Cocktail.class));
+        verify(varianteRepository).saveAll(anySet());
+        assertThat(result.id()).isEqualTo(1);
+    }
+
+    @Test
+    void getCocktailsGroupedByCategorie_groupsResults() {
+        Cocktail c1 = new Cocktail();
+        c1.setId(1);
+        c1.setLibelle("c1");
+        Categorie cat1 = new Categorie();
+        cat1.setIdCategorie(1);
+        cat1.setLibelle("A");
+        c1.setCategorie(cat1);
+        Cocktail c2 = new Cocktail();
+        c2.setId(2);
+        c2.setLibelle("c2");
+        c2.setCategorie(cat1);
+        when(cocktailRepository.findAll()).thenReturn(List.of(c1, c2));
+
+        Map<String, List<CocktailDto>> map = service.getCocktailsGroupedByCategorie();
+
+        assertThat(map).containsKey("A");
+        assertThat(map.get("A")).hasSize(2);
+    }
+
+    @Test
+    void deleteCocktail_whenMissing_throws() {
+        when(cocktailRepository.existsById(1)).thenReturn(false);
+        assertThatThrownBy(() -> service.deleteCocktail(1))
+                .isInstanceOf(ResourceAccessException.class);
+    }
+
+    @Test
+    void deleteCocktail_whenExists_deletes() {
+        when(cocktailRepository.existsById(1)).thenReturn(true);
+        Cocktail e = new Cocktail();
+        when(cocktailRepository.findById(1)).thenReturn(Optional.of(e));
+        service.deleteCocktail(1);
+        verify(cocktailRepository).delete(e);
+    }
+}

--- a/src/test/java/fr/thomasdindin/barapp/services/CommandeServiceImplTest.java
+++ b/src/test/java/fr/thomasdindin/barapp/services/CommandeServiceImplTest.java
@@ -1,0 +1,99 @@
+import fr.thomasdindin.barapp.dto.CommandeDto;
+import fr.thomasdindin.barapp.dto.LigneCommandeDto;
+import fr.thomasdindin.barapp.dto.VarianteDto;
+import fr.thomasdindin.barapp.entities.Commande;
+import fr.thomasdindin.barapp.entities.LigneCommande;
+import fr.thomasdindin.barapp.entities.Utilisateur;
+import fr.thomasdindin.barapp.entities.Variante;
+import fr.thomasdindin.barapp.enums.StatutCommande;
+import fr.thomasdindin.barapp.repositories.CommandeRepository;
+import fr.thomasdindin.barapp.repositories.LigneCommandeRepository;
+import fr.thomasdindin.barapp.repositories.UtilisateurRepository;
+import fr.thomasdindin.barapp.repositories.VarianteRepository;
+import fr.thomasdindin.barapp.services.CommandeServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.ResourceAccessException;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CommandeServiceImplTest {
+
+    @Mock
+    private CommandeRepository commandeRepository;
+    @Mock
+    private LigneCommandeRepository ligneCommandeRepository;
+    @Mock
+    private VarianteRepository varianteRepository;
+    @Mock
+    private UtilisateurRepository utilisateurRepository;
+    @InjectMocks
+    private CommandeServiceImpl service;
+
+    private Utilisateur user;
+    private Variante variante;
+
+    @BeforeEach
+    void setup() {
+        user = new Utilisateur();
+        user.setId(1);
+        variante = new Variante();
+        variante.setId(2);
+    }
+
+    @Test
+    void createCommande_buildsEntities() {
+        LigneCommandeDto lcDto = new LigneCommandeDto(null, 1, null, new VarianteDto(2, "M", null, 0));
+        CommandeDto dto = new CommandeDto(null, null, null, 1, Collections.singleton(lcDto));
+
+        when(utilisateurRepository.findById(1)).thenReturn(Optional.of(user));
+        when(commandeRepository.save(any(Commande.class))).thenAnswer(inv -> {Commande c = inv.getArgument(0); c.setId(5); return c;});
+        when(varianteRepository.findById(2)).thenReturn(Optional.of(variante));
+        when(ligneCommandeRepository.save(any(LigneCommande.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        CommandeDto res = service.createCommande(dto);
+
+        assertThat(res.id()).isEqualTo(5);
+        verify(ligneCommandeRepository).save(any(LigneCommande.class));
+    }
+
+    @Test
+    void updateLigneStatus_updatesCommandeStatut() {
+        Commande commande = new Commande();
+        commande.setId(10);
+        commande.setStatut(StatutCommande.EN_ATTENTE.getLibelle());
+        LigneCommande ligne = new LigneCommande();
+        ligne.setId(3);
+        ligne.setIdCommande(commande);
+        ligne.setStatut(StatutCommande.EN_ATTENTE.getLibelle());
+        commande.setLigneCommandes(new LinkedHashSet<>(Collections.singleton(ligne)));
+
+        when(ligneCommandeRepository.findById(3)).thenReturn(Optional.of(ligne));
+        when(commandeRepository.findById(10)).thenReturn(Optional.of(commande));
+        when(ligneCommandeRepository.save(any(LigneCommande.class))).thenReturn(ligne);
+        when(commandeRepository.save(any(Commande.class))).thenReturn(commande);
+
+        CommandeDto dto = service.updateLigneStatus(3, StatutCommande.EN_PREPARATION);
+
+        assertThat(commande.getStatut()).isEqualTo(StatutCommande.EN_PREPARATION.getLibelle());
+        assertThat(dto.statut()).isEqualTo(StatutCommande.EN_PREPARATION.getLibelle());
+    }
+
+    @Test
+    void getCommandeById_notFound() {
+        when(commandeRepository.findById(1)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.getCommandeById(1))
+                .isInstanceOf(ResourceAccessException.class);
+    }
+}

--- a/src/test/java/fr/thomasdindin/barapp/services/IngredientServiceImplTest.java
+++ b/src/test/java/fr/thomasdindin/barapp/services/IngredientServiceImplTest.java
@@ -1,0 +1,93 @@
+import fr.thomasdindin.barapp.dto.IngredientDto;
+import fr.thomasdindin.barapp.entities.Ingredient;
+import fr.thomasdindin.barapp.repositories.IngredientRepository;
+import fr.thomasdindin.barapp.services.IngredientServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.ResourceAccessException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class IngredientServiceImplTest {
+
+    @Mock
+    private IngredientRepository repository;
+
+    @InjectMocks
+    private IngredientServiceImpl service;
+
+    private Ingredient entity;
+
+    @BeforeEach
+    void setup() {
+        entity = new Ingredient();
+        entity.setId(1);
+        entity.setLibelle("Citron");
+    }
+
+    @Test
+    void createIngredient_savesAndReturnsDto() {
+        when(repository.save(any(Ingredient.class))).thenReturn(entity);
+        IngredientDto dto = new IngredientDto(null, "Citron");
+
+        IngredientDto res = service.createIngredient(dto);
+
+        assertThat(res.id()).isEqualTo(1);
+        assertThat(res.libelle()).isEqualTo("Citron");
+    }
+
+    @Test
+    void getAllIngredients_returnsList() {
+        when(repository.findAll()).thenReturn(List.of(entity));
+        List<IngredientDto> list = service.getAllIngredients();
+        assertThat(list).hasSize(1);
+    }
+
+    @Test
+    void getIngredientById_whenFound() {
+        when(repository.findById(1)).thenReturn(Optional.of(entity));
+        IngredientDto dto = service.getIngredientById(1);
+        assertThat(dto.id()).isEqualTo(1);
+    }
+
+    @Test
+    void getIngredientById_whenMissing_throws() {
+        when(repository.findById(1)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.getIngredientById(1))
+                .isInstanceOf(ResourceAccessException.class);
+    }
+
+    @Test
+    void updateIngredient_callsSave() {
+        when(repository.save(any(Ingredient.class))).thenReturn(entity);
+        IngredientDto dto = new IngredientDto(1, "Citron");
+        IngredientDto res = service.updateIngredient(dto);
+        assertThat(res.id()).isEqualTo(1);
+        verify(repository).save(any(Ingredient.class));
+    }
+
+    @Test
+    void deleteIngredient_whenFound() {
+        when(repository.findById(1)).thenReturn(Optional.of(entity));
+        service.deleteIngredient(1);
+        verify(repository).delete(entity);
+    }
+
+    @Test
+    void deleteIngredient_whenMissing_throws() {
+        when(repository.findById(1)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.deleteIngredient(1))
+                .isInstanceOf(ResourceAccessException.class);
+    }
+}

--- a/src/test/java/fr/thomasdindin/barapp/services/UtilisateurServiceImplTest.java
+++ b/src/test/java/fr/thomasdindin/barapp/services/UtilisateurServiceImplTest.java
@@ -1,0 +1,99 @@
+import fr.thomasdindin.barapp.dto.UserRegistrationDto;
+import fr.thomasdindin.barapp.entities.Utilisateur;
+import fr.thomasdindin.barapp.enums.Role;
+import fr.thomasdindin.barapp.repositories.UtilisateurRepository;
+import fr.thomasdindin.barapp.services.UtilisateurServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UtilisateurServiceImplTest {
+
+    @Mock
+    private UtilisateurRepository repository;
+    @Mock
+    private PasswordEncoder encoder;
+
+    @InjectMocks
+    private UtilisateurServiceImpl service;
+
+    private UserRegistrationDto dto;
+    private Utilisateur user;
+
+    @BeforeEach
+    void setup() {
+        dto = new UserRegistrationDto();
+        dto.setEmail("test@ex.com");
+        dto.setNom("n");
+        dto.setPrenom("p");
+        dto.setPassword("pw");
+        dto.setRole(Role.CLIENT);
+
+        user = new Utilisateur();
+        user.setId(1);
+        user.setEmail(dto.getEmail());
+        user.setMdp("enc");
+        user.setRole(Role.CLIENT);
+    }
+
+    @Test
+    void register_createsUser() {
+        when(repository.existsByEmail(dto.getEmail())).thenReturn(false);
+        when(repository.save(any(Utilisateur.class))).thenReturn(user);
+        when(encoder.encode("pw")).thenReturn("enc");
+
+        Utilisateur created = service.register(dto);
+
+        assertThat(created.getEmail()).isEqualTo("test@ex.com");
+        verify(repository).save(any(Utilisateur.class));
+    }
+
+    @Test
+    void register_existingEmail_throws() {
+        when(repository.existsByEmail(dto.getEmail())).thenReturn(true);
+        assertThatThrownBy(() -> service.register(dto))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void getByEmail_whenFound() {
+        when(repository.findByEmail("a@b.c")).thenReturn(Optional.of(user));
+        Utilisateur res = service.getByEmail("a@b.c");
+        assertThat(res).isSameAs(user);
+    }
+
+    @Test
+    void getByEmail_whenMissing_throws() {
+        when(repository.findByEmail("a@b.c")).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.getByEmail("a@b.c"))
+                .isInstanceOf(UsernameNotFoundException.class);
+    }
+
+    @Test
+    void loadUserByUsername_returnsUserDetails() {
+        when(repository.findByEmail("x@y.z")).thenReturn(Optional.of(user));
+        UserDetails details = service.loadUserByUsername("x@y.z");
+        assertThat(details.getUsername()).isEqualTo("test@ex.com");
+    }
+
+    @Test
+    void loadUserByUsername_notFound() {
+        when(repository.findByEmail("x@y.z")).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.loadUserByUsername("x@y.z"))
+                .isInstanceOf(UsernameNotFoundException.class);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for service implementations covering CRUD logic
- ensure each service class has direct unit tests

## Testing
- `./mvnw test` *(fails: repository download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686542f1e3c88332b2268e292e9b5f0c